### PR TITLE
add public flag to config

### DIFF
--- a/AeroGearOAuth2/OAuth2Module.swift
+++ b/AeroGearOAuth2/OAuth2Module.swift
@@ -50,7 +50,7 @@ open class OAuth2Module: AuthzModule {
      :param: completionHandler A block object to be executed when the request operation finishes.
      */
 
-    let config: Config
+    public let config: Config
     open var http: Http
     open var oauth2Session: OAuth2Session
     var applicationLaunchNotificationObserver: NSObjectProtocol?


### PR DESCRIPTION
## Motivation
I need to create a custom Module and need to access the `config` value to get some 
In order to have it in scope  we need `config` go be visible outside the pod.
This lead to add the flag `public` to achieve the goal.

## What
Expose `config` to be used in subclasses outside the pod.

## Why
Avoid compiler raising error for `config is inaccesible due to internal protection level`

## How
Forcing `public` the variable

## Verification Steps
To verify create a class like:

```swift
open class TestModule: OAuth2Module {
    open override func login(completionHandler: @escaping (AnyObject?, OpenIdClaim?, NSError?) -> Void) {
        let clientSecret = config.clientSecret
    }
}
```

This with public pod will raise error, applying the PR it allow me to have in scope config and access that as it happens in any other subclass of OAuth2Module.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task


## Additional Notes

None

